### PR TITLE
feat: レポートチャンネルにcron登録/解除とチャットエラー詳細を通知

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ OpenClaw 風の AI エージェント。Vercel AI SDK + Chat SDK + OpenAI + Disc
 - `webFetch` / `webSearch` による Web 情報取得（Readability + Brave Search API）
 - `data/HEARTBEAT.md` と `data/cron/*/CRON.md` による Heartbeat / Cron 実行
 - `postMessage` / `manageCron` ツールによる管理者限定のプロアクティブ投稿と Cron 管理
+- `REPORT_CHANNEL_ID` への Heartbeat / Cron 実行結果、Cron 登録変更、チャット処理エラー詳細の通知
 - Discord メッセージに処理状態を表すリアクション絵文字を表示（完了は 2 秒後に除去、エラーは保持）
 - 各層をインターフェースで抽象化し、実装の差し替えが容易
 - v1 はテキストメッセージのみ対応
@@ -48,7 +49,7 @@ Discord Gateway listener を同時に起動する。
 - `webSearch` は `BRAVE_API_KEY` 設定時のみ有効。Brave Search API で Web 検索を行う
 - `postMessage` / `manageCron` は `ALLOWED_CHANNEL_IDS` と `ADMIN_USER_IDS` が設定された管理者コンテキストでのみ公開される
 - Heartbeat は `ALLOWED_CHANNEL_IDS` 設定時のみ有効化され、`REPORT_CHANNEL_ID` は空欄のままでも省略設定として扱われる
-- `REPORT_CHANNEL_ID` を設定すると Heartbeat / Cron の実行成否を自動投稿する（エージェント応答本文は自動投稿しない）
+- `REPORT_CHANNEL_ID` を設定すると Heartbeat / Cron の実行成否、`manageCron` による登録/解除、チャット処理エラー詳細を自動投稿する（エージェント応答本文は自動投稿しない）
 - Chat SDK の state は `DATA_DIR/state/chat-state.json` に保存するカスタム JSON アダプターを使用
 - Memory / Session も `data/` 配下にファイル保存
 - 元メッセージへのリアクションで `queued` / `thinking` / tool 実行中 / `done` / `error` を表示し、`done` は 2 秒後に自動除去する

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -168,6 +168,7 @@ export class KarakuriAgent implements IAgent {
       braveApiKey: this.config.braveApiKey,
       postMessageEnabled: hasPostMessage,
       postMessageChannelIds: this.config.postMessageChannelIds,
+      reportChannelId: this.config.reportChannelId,
       adminUserIds: this.config.adminUserIds,
       userId: options?.userId,
       ...(this.skillStore != null ? { skillStore: this.skillStore } : {}),

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -17,6 +17,7 @@ export interface CreateAgentToolsOptions {
   skillStore?: ISkillStore | undefined;
   skills?: SkillDefinition[] | undefined;
   messageSink?: IMessageSink | undefined;
+  reportChannelId?: string | undefined;
   postMessageEnabled?: boolean | undefined;
   postMessageChannelIds?: string[] | undefined;
   schedulerStore?: ISchedulerStore | undefined;
@@ -31,6 +32,7 @@ export function createAgentTools({
   skillStore,
   skills = [],
   messageSink,
+  reportChannelId,
   postMessageEnabled,
   postMessageChannelIds,
   schedulerStore,
@@ -72,6 +74,8 @@ export function createAgentTools({
             schedulerStore: schedulerStore!,
             adminUserIds,
             userId,
+            messageSink,
+            reportChannelId,
           }),
         }
       : {}),

--- a/src/agent/tools/manage-cron.ts
+++ b/src/agent/tools/manage-cron.ts
@@ -1,8 +1,12 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
-import type { ISchedulerStore } from '../../scheduler/types.js';
+import type { IMessageSink, ISchedulerStore } from '../../scheduler/types.js';
+import { createLogger } from '../../utils/logger.js';
+import { reportSafely } from '../../utils/report.js';
 import { assertAdminUser } from './admin-auth.js';
+
+const logger = createLogger('ManageCronTool');
 
 const manageCronSchema = z.object({
   action: z.enum(['register', 'unregister', 'list']),
@@ -18,9 +22,17 @@ export interface ManageCronToolOptions {
   schedulerStore: ISchedulerStore;
   adminUserIds: string[];
   userId?: string | undefined;
+  messageSink?: IMessageSink | undefined;
+  reportChannelId?: string | undefined;
 }
 
-export function createManageCronTool({ schedulerStore, adminUserIds, userId }: ManageCronToolOptions) {
+export function createManageCronTool({
+  schedulerStore,
+  adminUserIds,
+  userId,
+  messageSink,
+  reportChannelId,
+}: ManageCronToolOptions) {
   return tool({
     description: 'Register, update, unregister, or list cron jobs. For register/unregister, name is required. For register, schedule and instructions are also required.',
     inputSchema: manageCronSchema,
@@ -40,6 +52,12 @@ export function createManageCronTool({ schedulerStore, adminUserIds, userId }: M
             ...(input.sessionMode != null ? { sessionMode: input.sessionMode } : {}),
             ...(input.staggerMs != null ? { staggerMs: input.staggerMs } : {}),
           });
+          void reportSafely(
+            messageSink,
+            reportChannelId,
+            `⏰ Cron \`${job.name}\` saved (schedule: ${job.schedule})`,
+            logger,
+          );
           return { action: 'register', job };
         }
         case 'unregister': {
@@ -47,6 +65,14 @@ export function createManageCronTool({ schedulerStore, adminUserIds, userId }: M
             throw new Error('unregister requires name');
           }
           const removed = await schedulerStore.unregisterJob(input.name);
+          if (removed) {
+            void reportSafely(
+              messageSink,
+              reportChannelId,
+              `🗑️ Cron \`${input.name}\` unregistered`,
+              logger,
+            );
+          }
           return { action: 'unregister', name: input.name, removed };
         }
         case 'list': {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -3,11 +3,14 @@ import { Chat, type Message, type Thread } from 'chat';
 
 import type { Config } from './config.js';
 import type { AgentLifecycleCallbacks, IAgent } from './agent/core.js';
+import type { IMessageSink } from './scheduler/types.js';
 import { StatusReactionController } from './status-reaction.js';
 import { createFileStateAdapter } from './state/file-state.js';
+import { formatError } from './utils/error.js';
 import { createLogger } from './utils/logger.js';
 import { splitMessageForDiscord } from './utils/message-splitter.js';
 import { KeyedMutex } from './utils/mutex.js';
+import { reportSafely } from './utils/report.js';
 
 const logger = createLogger('Bot');
 
@@ -34,7 +37,11 @@ export interface BotRuntime {
   shutdown(): Promise<void>;
 }
 
-export function createBot(config: Config, agent: IAgent): BotRuntime {
+export interface CreateBotOptions {
+  messageSink?: IMessageSink | undefined;
+}
+
+export function createBot(config: Config, agent: IAgent, options?: CreateBotOptions): BotRuntime {
   const threadMutex = new KeyedMutex();
   const inFlightHandlers = new Set<Promise<void>>();
   const chat = new Chat<KarakuriAdapters>({
@@ -84,7 +91,21 @@ export function createBot(config: Config, agent: IAgent): BotRuntime {
       } catch (error) {
         controller.error();
         logger.error('Failed to handle new message', error);
-        await safePost(thread, ERROR_MESSAGE);
+        try {
+          await safePost(thread, ERROR_MESSAGE);
+        } catch (postError) {
+          logger.error('Failed to send new-message error reply', postError);
+        }
+        void reportSafely(
+          options?.messageSink,
+          config.reportChannelId,
+          `❌ Chat error (message: ${message.id})\n${formatError(error)}`,
+          {
+            error: (_message, reportError) => {
+              logger.error('Failed to report new-message error', reportError);
+            },
+          },
+        );
       }
     });
     await controller.waitForCompletion();
@@ -108,7 +129,21 @@ export function createBot(config: Config, agent: IAgent): BotRuntime {
         } catch (error) {
           controller.error();
           logger.error('Failed to handle subscribed message', error);
-          await safePost(thread, ERROR_MESSAGE);
+          try {
+            await safePost(thread, ERROR_MESSAGE);
+          } catch (postError) {
+            logger.error('Failed to send subscribed-message error reply', postError);
+          }
+          void reportSafely(
+            options?.messageSink,
+            config.reportChannelId,
+            `❌ Chat error (message: ${message.id})\n${formatError(error)}`,
+            {
+              error: (_message, reportError) => {
+                logger.error('Failed to report subscribed-message error', reportError);
+              },
+            },
+          );
         }
       }).then(() => controller.waitForCompletion()),
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ async function main(): Promise<void> {
     messageSink,
     store: schedulerStore,
   });
-  const bot = createBot(config, agent);
+  const bot = createBot(config, agent, { messageSink });
 
   await bot.initialize();
   logger.debug('Bot initialized');

--- a/src/scheduler/cron-runner.ts
+++ b/src/scheduler/cron-runner.ts
@@ -3,6 +3,7 @@ import { Cron } from 'croner';
 import type { IAgent } from '../agent/core.js';
 import { formatError } from '../utils/error.js';
 import { createLogger } from '../utils/logger.js';
+import { reportSafely } from '../utils/report.js';
 import type { CronJobDefinition, IMessageSink, ISchedulerStore } from './types.js';
 
 const logger = createLogger('CronRunner');
@@ -209,39 +210,49 @@ export class CronRunner {
             },
           );
           logger.debug('Cron run completed', { name: job.name, responseLength: response.trim().length });
-          await this.reportSafely(job.name, `✅ Cron ${job.name} succeeded in ${this.now().getTime() - startedAt.getTime()}ms`);
+          await reportSafely(
+            this.options.messageSink,
+            this.options.reportChannelId,
+            `✅ Cron ${job.name} succeeded in ${this.now().getTime() - startedAt.getTime()}ms`,
+            {
+              error: (_message, error) => {
+                logger.error(`Cron job ${job.name} report failed`, error);
+              },
+            },
+          );
         } catch (error) {
           logger.error(`Cron job ${job.name} failed`, error);
-          await this.reportSafely(job.name, `❌ Cron ${job.name} failed in ${this.now().getTime() - startedAt.getTime()}ms\n${formatError(error)}`);
+          await reportSafely(
+            this.options.messageSink,
+            this.options.reportChannelId,
+            `❌ Cron ${job.name} failed in ${this.now().getTime() - startedAt.getTime()}ms\n${formatError(error)}`,
+            {
+              error: (_message, reportError) => {
+                logger.error(`Cron job ${job.name} report failed`, reportError);
+              },
+            },
+          );
         }
       })();
       state.inFlight = inFlight;
       await inFlight;
     } catch (error) {
       logger.error(`Cron job ${job.name} failed`, error);
-      await this.reportSafely(job.name, `❌ Cron ${job.name} failed in ${this.now().getTime() - startedAt.getTime()}ms\n${formatError(error)}`);
+      await reportSafely(
+        this.options.messageSink,
+        this.options.reportChannelId,
+        `❌ Cron ${job.name} failed in ${this.now().getTime() - startedAt.getTime()}ms\n${formatError(error)}`,
+        {
+          error: (_message, reportError) => {
+            logger.error(`Cron job ${job.name} report failed`, reportError);
+          },
+        },
+      );
     } finally {
       if (state.inFlight === inFlight) {
         state.inFlight = null;
       }
     }
-  }
-
-  private async reportSafely(name: string, text: string): Promise<void> {
-    try {
-      await this.report(name, text);
-    } catch (error) {
-      logger.error(`Cron job ${name} report failed`, error);
-    }
-  }
-
-  private async report(name: string, text: string): Promise<void> {
-    if (this.options.messageSink == null || this.options.reportChannelId == null) {
-      return;
-    }
-
-    await this.options.messageSink.postMessage(this.options.reportChannelId, text);
-    logger.debug('Cron run reported', { name });
   }
 
   private cancelState(state: CronState): void {

--- a/src/scheduler/heartbeat.ts
+++ b/src/scheduler/heartbeat.ts
@@ -1,6 +1,7 @@
 import type { IAgent } from '../agent/core.js';
 import { formatError } from '../utils/error.js';
 import { createLogger } from '../utils/logger.js';
+import { reportSafely } from '../utils/report.js';
 import type { IMessageSink, ISchedulerStore } from './types.js';
 
 const logger = createLogger('HeartbeatRunner');
@@ -129,26 +130,28 @@ export class HeartbeatRunner {
         },
       );
       logger.debug('Heartbeat run completed', { responseLength: response.trim().length });
-      await this.reportSafely(`✅ Heartbeat succeeded in ${this.now().getTime() - startedAt.getTime()}ms`);
+      await reportSafely(
+        this.options.messageSink,
+        this.options.reportChannelId,
+        `✅ Heartbeat succeeded in ${this.now().getTime() - startedAt.getTime()}ms`,
+        {
+          error: (_message, error) => {
+            logger.error('Heartbeat report failed', error);
+          },
+        },
+      );
     } catch (error) {
       logger.error('Heartbeat run failed', error);
-      await this.reportSafely(`❌ Heartbeat failed in ${this.now().getTime() - startedAt.getTime()}ms\n${formatError(error)}`);
+      await reportSafely(
+        this.options.messageSink,
+        this.options.reportChannelId,
+        `❌ Heartbeat failed in ${this.now().getTime() - startedAt.getTime()}ms\n${formatError(error)}`,
+        {
+          error: (_message, reportError) => {
+            logger.error('Heartbeat report failed', reportError);
+          },
+        },
+      );
     }
-  }
-
-  private async reportSafely(text: string): Promise<void> {
-    try {
-      await this.report(text);
-    } catch (error) {
-      logger.error('Heartbeat report failed', error);
-    }
-  }
-
-  private async report(text: string): Promise<void> {
-    if (this.options.messageSink == null || this.options.reportChannelId == null) {
-      return;
-    }
-
-    await this.options.messageSink.postMessage(this.options.reportChannelId, text);
   }
 }

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -1,0 +1,19 @@
+import type { IMessageSink } from '../scheduler/types.js';
+import type { Logger } from './logger.js';
+
+export async function reportSafely(
+  messageSink: IMessageSink | null | undefined,
+  reportChannelId: string | null | undefined,
+  text: string,
+  loggerInstance: Pick<Logger, 'error'>,
+): Promise<void> {
+  if (messageSink == null || reportChannelId == null) {
+    return;
+  }
+
+  try {
+    await messageSink.postMessage(reportChannelId, text);
+  } catch (error) {
+    loggerInstance.error('Failed to send report message', error);
+  }
+}

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -260,6 +260,109 @@ describe('createBot', () => {
     );
   });
 
+  it('reports new-message handler errors to the report channel', async () => {
+    const messageSink = { postMessage: vi.fn(async () => {}) };
+    const agent: IAgent = {
+      async handleMessage(): Promise<string> {
+        throw new Error('boom detail');
+      },
+      async summarizeSession(): Promise<string> {
+        return 'summary';
+      },
+    };
+
+    const bot = createBot({ ...baseConfig, reportChannelId: 'report' }, agent, { messageSink });
+    const chat = bot.chat as unknown as {
+      _getNewMessageHandlers(): ((thread: unknown, message: unknown) => Promise<void>)[];
+    };
+    const handler = chat._getNewMessageHandlers()[0]!;
+    const { thread } = createMockThread();
+
+    await expect(handler(thread, createMessage())).resolves.toBeUndefined();
+
+    expect(thread.post).toHaveBeenCalledWith(expect.stringContaining('エラーが発生しました'));
+    expect(messageSink.postMessage).toHaveBeenCalledWith(
+      'report',
+      '❌ Chat error (message: message-1)\nboom detail',
+    );
+  });
+
+  it('reports subscribed-message handler errors to the report channel', async () => {
+    const messageSink = { postMessage: vi.fn(async () => {}) };
+    const agent: IAgent = {
+      async handleMessage(): Promise<string> {
+        throw new Error('boom detail');
+      },
+      async summarizeSession(): Promise<string> {
+        return 'summary';
+      },
+    };
+
+    const bot = createBot({ ...baseConfig, reportChannelId: 'report' }, agent, { messageSink });
+    const chat = bot.chat as unknown as {
+      _getSubscribedMessageHandlers(): ((thread: unknown, message: unknown) => Promise<void>)[];
+    };
+    const handler = chat._getSubscribedMessageHandlers()[0]!;
+    const { thread } = createMockThread();
+
+    await expect(handler(thread, createMessage())).resolves.toBeUndefined();
+
+    expect(thread.post).toHaveBeenCalledWith(expect.stringContaining('エラーが発生しました'));
+    expect(messageSink.postMessage).toHaveBeenCalledWith(
+      'report',
+      '❌ Chat error (message: message-1)\nboom detail',
+    );
+  });
+
+  it('reports chat errors even when posting the user-facing error reply fails', async () => {
+    const messageSink = { postMessage: vi.fn(async () => {}) };
+    const agent: IAgent = {
+      async handleMessage(): Promise<string> {
+        throw new Error('boom detail');
+      },
+      async summarizeSession(): Promise<string> {
+        return 'summary';
+      },
+    };
+
+    const bot = createBot({ ...baseConfig, reportChannelId: 'report' }, agent, { messageSink });
+    const chat = bot.chat as unknown as {
+      _getSubscribedMessageHandlers(): ((thread: unknown, message: unknown) => Promise<void>)[];
+    };
+    const handler = chat._getSubscribedMessageHandlers()[0]!;
+    const { thread } = createMockThread();
+    thread.post.mockRejectedValueOnce(new Error('post failed'));
+
+    await expect(handler(thread, createMessage())).resolves.toBeUndefined();
+
+    expect(messageSink.postMessage).toHaveBeenCalledWith(
+      'report',
+      '❌ Chat error (message: message-1)\nboom detail',
+    );
+  });
+
+  it('does not crash when reporting a chat error fails', async () => {
+    const messageSink = { postMessage: vi.fn(async () => { throw new Error('report failed'); }) };
+    const agent: IAgent = {
+      async handleMessage(): Promise<string> {
+        throw new Error('boom detail');
+      },
+      async summarizeSession(): Promise<string> {
+        return 'summary';
+      },
+    };
+
+    const bot = createBot({ ...baseConfig, reportChannelId: 'report' }, agent, { messageSink });
+    const chat = bot.chat as unknown as {
+      _getSubscribedMessageHandlers(): ((thread: unknown, message: unknown) => Promise<void>)[];
+    };
+    const handler = chat._getSubscribedMessageHandlers()[0]!;
+    const { thread } = createMockThread();
+
+    await expect(handler(thread, createMessage())).resolves.toBeUndefined();
+    expect(thread.post).toHaveBeenCalledWith(expect.stringContaining('エラーが発生しました'));
+  });
+
   it('replies with attachment-only message when text is empty', async () => {
     const agent: IAgent = {
       async handleMessage(): Promise<string> {

--- a/tests/manage-cron.test.ts
+++ b/tests/manage-cron.test.ts
@@ -4,6 +4,7 @@ import { createManageCronTool } from '../src/agent/tools/manage-cron.js';
 
 describe('manageCron tool', () => {
   it('registers, lists, and unregisters jobs for admin users', async () => {
+    const messageSink = { postMessage: vi.fn(async () => {}) };
     const schedulerStore = {
       registerJob: vi.fn(async (input) => ({
         name: input.name,
@@ -30,12 +31,19 @@ describe('manageCron tool', () => {
       schedulerStore,
       adminUserIds: ['admin-1'],
       userId: 'admin-1',
+      messageSink,
+      reportChannelId: 'report',
     });
 
     await expect(tool.execute!(
       { action: 'register', name: 'daily-summary', schedule: '0 9 * * *', instructions: 'Run.' },
       { toolCallId: 'c1', messages: [], abortSignal: undefined as never },
     )).resolves.toMatchObject({ action: 'register', job: { name: 'daily-summary' } });
+    expect(messageSink.postMessage).toHaveBeenNthCalledWith(
+      1,
+      'report',
+      '⏰ Cron `daily-summary` saved (schedule: 0 9 * * *)',
+    );
 
     await expect(tool.execute!(
       { action: 'list' },
@@ -56,6 +64,11 @@ describe('manageCron tool', () => {
       { action: 'unregister', name: 'daily-summary' },
       { toolCallId: 'c3', messages: [], abortSignal: undefined as never },
     )).resolves.toEqual({ action: 'unregister', name: 'daily-summary', removed: true });
+    expect(messageSink.postMessage).toHaveBeenNthCalledWith(
+      2,
+      'report',
+      '🗑️ Cron `daily-summary` unregistered',
+    );
   });
 
   it('rejects non-admin users', async () => {
@@ -98,5 +111,65 @@ describe('manageCron tool', () => {
       { toolCallId: 'c1', messages: [], abortSignal: undefined as never },
     )).resolves.toEqual({ action: 'list', jobs: [] });
     expect(schedulerStore.listCronJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not report unregister when no job was removed', async () => {
+    const messageSink = { postMessage: vi.fn(async () => {}) };
+    const tool = createManageCronTool({
+      schedulerStore: {
+        registerJob: vi.fn(),
+        unregisterJob: vi.fn(async () => false),
+        listCronJobs: vi.fn(async () => []),
+        readHeartbeatInstructions: vi.fn(async () => null),
+        setReloadListener: vi.fn(),
+        close: vi.fn(async () => {}),
+      },
+      adminUserIds: ['admin-1'],
+      userId: 'admin-1',
+      messageSink,
+      reportChannelId: 'report',
+    });
+
+    await expect(tool.execute!(
+      { action: 'unregister', name: 'daily-summary' },
+      { toolCallId: 'c1', messages: [], abortSignal: undefined as never },
+    )).resolves.toEqual({ action: 'unregister', name: 'daily-summary', removed: false });
+    expect(messageSink.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('swallows report failures for register and unregister', async () => {
+    const messageSink = { postMessage: vi.fn(async () => { throw new Error('report failed'); }) };
+    const schedulerStore = {
+      registerJob: vi.fn(async (input) => ({
+        name: input.name,
+        schedule: input.schedule,
+        instructions: input.instructions,
+        enabled: input.enabled ?? true,
+        sessionMode: input.sessionMode ?? 'isolated',
+        staggerMs: input.staggerMs ?? 0,
+      })),
+      unregisterJob: vi.fn(async () => true),
+      listCronJobs: vi.fn(async () => []),
+      readHeartbeatInstructions: vi.fn(async () => null),
+      setReloadListener: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const tool = createManageCronTool({
+      schedulerStore,
+      adminUserIds: ['admin-1'],
+      userId: 'admin-1',
+      messageSink,
+      reportChannelId: 'report',
+    });
+
+    await expect(tool.execute!(
+      { action: 'register', name: 'daily-summary', schedule: '0 9 * * *', instructions: 'Run.' },
+      { toolCallId: 'c1', messages: [], abortSignal: undefined as never },
+    )).resolves.toMatchObject({ action: 'register', job: { name: 'daily-summary' } });
+
+    await expect(tool.execute!(
+      { action: 'unregister', name: 'daily-summary' },
+      { toolCallId: 'c2', messages: [], abortSignal: undefined as never },
+    )).resolves.toEqual({ action: 'unregister', name: 'daily-summary', removed: true });
   });
 });


### PR DESCRIPTION
## Summary

- `reportSafely` ヘルパーを `src/utils/report.ts` に共通化し、cron-runner / heartbeat の重複コードを削除
- `manageCron` ツールで cron 登録/解除時にレポートチャンネルへ通知を送信
- `bot.ts` の catch ブロックでチャットエラー詳細をレポートチャンネルへ通知（`safePost` 失敗時も独立して送信）

## Test plan

- [x] `tests/manage-cron.test.ts` - register/unregister 時のレポート送信を検証
- [x] `tests/manage-cron.test.ts` - unregister で removed=false の場合はレポートしないことを検証
- [x] `tests/manage-cron.test.ts` - レポート失敗時にツール呼び出し自体は成功することを検証
- [x] `tests/bot.test.ts` - new-message / subscribed-message エラー時のレポート送信を検証
- [x] `tests/bot.test.ts` - thread.post 失敗時でもレポートが送られることを検証
- [x] `tests/bot.test.ts` - レポート送信自体が失敗してもハンドラーがクラッシュしないことを検証
- [x] `tests/cron-runner.test.ts` / `tests/heartbeat.test.ts` - 既存テストが通ることを確認
- [x] `tsc --noEmit` 型チェック通過

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)