### PR TITLE
feat: 日記ストレージをファイルベースからSQLiteに移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ OpenClaw 風の AI エージェント。Vercel AI SDK + Chat SDK + OpenAI 互換
 
 ## 特徴
 
-- ファイルベースのメモリ・セッション管理（write-through キャッシュ付き）
+- ファイルベースのコアメモリ・セッション管理（write-through キャッシュ付き）
+- SQLite による日記永続化と直近範囲検索
 - SQLite によるユーザー情報・プロフィール永続化と応答後の自動評価更新
 - `data/AGENT.md` / `data/RULES.md` / `data/skills/*/SKILL.md` による Markdown-first の prompt / skill 拡張
 - trusted prompt context / skills は `fs.watch()` で eager reload、memory は write-through + watcher で外部変更に追随
@@ -101,7 +102,8 @@ npm run docker:dev
 - Heartbeat は `ALLOWED_CHANNEL_IDS` 設定時のみ有効化され、`REPORT_CHANNEL_ID` は空欄のままでも省略設定として扱われる
 - `REPORT_CHANNEL_ID` を設定すると Heartbeat / Cron の実行成否、`manageCron` による登録/解除、チャット処理エラー詳細を自動投稿する（エージェント応答本文は自動投稿しない）
 - Chat SDK の state は `DATA_DIR/state/chat-state.json` に保存するカスタム JSON アダプターを使用
-- Memory / Session も `data/` 配下にファイル保存
+- コアメモリ / Session は `data/` 配下にファイル保存し、日記は `DATA_DIR/diary.db` に保存する
+- 初回起動時は旧 `DATA_DIR/memory/diary/*.md` を検出すると `diary.db` へ一度だけ自動インポートする
 - ユーザー情報は `DATA_DIR/users.db` に保存され、`userLookup` ツールと `<user-profile>` コンテキストに利用される
 - 元メッセージへのリアクションで `queued` / `thinking` / tool 実行中 / `done` / `error` を表示し、`done` は 2 秒後に自動除去する
 - 添付ファイルは未対応。添付付きメッセージはテキスト部分のみ処理し、注意メッセージを返す

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,7 +15,7 @@ Discord ──→ Chat SDK (bot.ts) ──→ Agent Core
                 │                      ├── Tools (recallDiary, userLookup*, webFetch, webSearch*, loadSkill*, skill-gated tools*)
                 │                      ├── Prompt Context (AGENT.md / RULES.md, eager reload)
                 │                      ├── Skills (data/skills/*/SKILL.md, eager reload)
-                │                      ├── Memory (file-based, write-through cache + watcher + mutex付き)
+                │                      ├── Memory (CompositeMemoryStore: file core + SQLite diary)
                 │                      └── Session (file-based, write-through cache + turn単位管理)
                 │
                 └── State (JSON file-backed custom adapter)
@@ -30,7 +30,7 @@ Discord ──→ Chat SDK (bot.ts) ──→ Agent Core
 | ------- | ------------------ | --------------------------- | ----------------------- |
 | Channel | Chat SDK adapters  | Discord                     | Slack, Web 等            |
 | Agent   | `IAgent`           | generateText + OpenAI-compatible LLM | モデル/API切替、スキル追加  |
-| Memory  | `IMemoryStore`     | ファイルベース (write-through cache + mutex 付き) | SQLite, object storage |
+| Memory  | `IMemoryStore`     | CompositeMemoryStore（file core + SQLite diary） | object storage, external DB |
 | Session | `ISessionManager`  | JSON ファイル (write-through cache) | Redis, DB |
 
 ## プロジェクト構造
@@ -53,7 +53,9 @@ karakuri-agent/
 │   │       ├── web-fetch.ts       # URL取得 + Readability/Turndown
 │   │       └── web-search.ts      # Brave Search API 連携
 │   ├── memory/
-│   │   ├── store.ts            # IMemoryStore + FileMemoryStore (write-through cache + watcher + mutex + atomic write)
+│   │   ├── composite-store.ts  # IMemoryStore + CompositeMemoryStore
+│   │   ├── diary-store.ts      # SqliteDiaryStore (SQLite diary)
+│   │   ├── store.ts            # FileMemoryStore (core memory only)
 │   │   └── types.ts
 │   ├── skill/
 │   │   ├── frontmatter.ts      # SKILL.md frontmatter parser
@@ -73,11 +75,10 @@ karakuri-agent/
 │   └── index.ts                # エントリポイント
 ├── tests/                      # Memory / Session / Agent / utility unit test
 ├── data/                       # .gitignoreで全体を除外
+│   ├── diary.db                # 日記（直近3日分は自動注入）
 │   ├── memory/
-│   │   ├── core/
-│   │   │   └── memory.md       # 重要な記憶（常時システムプロンプトに注入）
-│   │   └── diary/
-│   │       └── YYYY-MM-DD.md   # 日記（直近3日分は自動注入）
+│   │   └── core/
+│   │       └── memory.md       # 重要な記憶（常時システムプロンプトに注入）
 │   ├── AGENT.md                # 任意: trusted なエージェント人格
 │   ├── RULES.md                # 任意: trusted な行動ルール
 │   └── skills/
@@ -152,10 +153,13 @@ karakuri-agent/
 
 ### Phase 2: Memory 層
 
-- `src/memory/types.ts` (IMemoryStore)
-- `src/memory/store.ts` (FileMemoryStore: write-through cache + mutex + atomic write)
+- `src/memory/types.ts` (IMemoryStore / ICoreMemoryStore / IDiaryStore)
+- `src/memory/store.ts` (FileMemoryStore: core memory file store)
+- `src/memory/diary-store.ts` (SqliteDiaryStore: diary SQLite store)
+- `src/memory/composite-store.ts` (CompositeMemoryStore)
 - `data/memory/core/memory.md`（空 or 初期内容）
-- **unit test**: read/write/append/concurrent write
+- `data/diary.db`
+- **unit test**: core read/write/append/concurrent write, diary append/range/date listing
 
 ### Phase 3: Session 層
 
@@ -186,7 +190,7 @@ karakuri-agent/
 - `npm run dev` で起動
 - Discord でメッセージ送信 → 応答確認（メンション不要）
 - 再起動後の follow-up 継続確認（永続 state）
-- メモリ保存・読み込み確認（memory.md, diary）
+- メモリ保存・読み込み確認（memory.md, diary.db）
 - ユーザー情報保存確認（users.db, user profile prompt, userLookup）
 - ボット再起動後のメモリ永続化確認
 - 長い会話でセッション要約が動作するか確認（turn 単位で壊れないか）
@@ -197,7 +201,7 @@ karakuri-agent/
 1. **Chat SDK は beta**: exact version 固定 + lockfile コミット必須。破壊的変更に備える
 2. **Discord Gateway 接続**: Chat SDK の Discord アダプターが長時間稼働で安定するか Phase 0 で検証。問題時は discord.js 直接使用にフォールバック
 3. **AI SDK v6 API**: `stopWhen: stepCountIs(n)`, `ModelMessage` 型を使用（ai-sdk.dev/docs で確認済み）
-4. **ファイル I/O 競合**: memory.md・当日 diary は全スレッド共有。mutex + atomic write 必須
+4. **永続化競合**: memory.md は mutex + atomic write、diary は SQLite WAL で整合性を保つ
 5. **Prompt injection**: memory/diary/user profile 内容はタグで区切り、instruction 部分と明確分離する
 6. **コンテキスト予算**: メッセージ件数ではなくトークン予算ベースで要約トリガー管理
 7. **Timezone**: diary 日付は `config.timezone`（デフォルト `Asia/Tokyo`）基準

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -2,88 +2,108 @@
 
 ## 概要
 
-会話から得た重要な記憶（`core`）と日付ごとの日記（`diary`）をファイルで永続化する層。
-複数スレッドからの同時アクセスを mutex + atomic write で保護する。
+会話から得た重要な記憶（`core`）と日付ごとの日記（`diary`）を永続化する層。
+コアメモリはファイル、日記は SQLite に保存し、`CompositeMemoryStore` が既存の `IMemoryStore` を維持したまま両者を束ねる。
 
-## インターフェース: `IMemoryStore` (`src/memory/types.ts`)
+## インターフェース: `src/memory/types.ts`
 
 ```typescript
-interface IMemoryStore {
-  /** memory.md 読み込み */
+interface ICoreMemoryStore {
   readCoreMemory(): Promise<string>;
-
-  /**
-   * memory.md 書き込み（append のみ）
-   * replace はモデルに開放しない（prompt injection 固定化防止）
-   */
   writeCoreMemory(content: string, mode: 'append'): Promise<void>;
-
-  /** 指定日の diary 読み込み（存在しなければ null） */
-  readDiary(date: string): Promise<string | null>;
-
-  /** 指定日の diary に追記 */
-  writeDiary(date: string, content: string): Promise<void>;
-
-  /** 直近 N 日分の diary を取得 */
-  getRecentDiaries(days: number): Promise<Array<{ date: string; content: string }>>;
-
-  /** 保存済みの diary 日付一覧 */
-  listDiaryDates(): Promise<string[]>;
+  close(): Promise<void>;
 }
+
+interface IDiaryStore {
+  readDiary(date: string): Promise<string | null>;
+  writeDiary(date: string, content: string): Promise<void>;
+  getRecentDiaries(days: number): Promise<Array<{ date: string; content: string }>>;
+  listDiaryDates(): Promise<string[]>;
+  close(): Promise<void>;
+}
+
+interface IMemoryStore extends ICoreMemoryStore, IDiaryStore {}
 ```
 
-## 実装: `FileMemoryStore` (`src/memory/store.ts`)
+## 実装構成
 
-### ファイルレイアウト
+### `FileMemoryStore` (`src/memory/store.ts`)
 
+- `DATA_DIR/memory/core/memory.md` を管理する core memory 専用ストア
+- `write-through cache + watcher` で外部変更を再読込する
+- `memory.md` の追記は `KeyedMutex` + atomic write で保護する
+
+### `SqliteDiaryStore` (`src/memory/diary-store.ts`)
+
+- `DATA_DIR/diary.db` を管理する diary 専用ストア
+- SQLite pragma は `journal_mode=WAL`, `synchronous=NORMAL`
+- append-only な `diary_entries` テーブルに日記を蓄積する
+- 同日複数エントリは `id ASC` 順に結合して返す
+- 直近 N 日の取得は SQL で日付範囲を絞り、TypeScript 側で日付単位にグルーピングする
+- 旧 `DATA_DIR/memory/diary/YYYY-MM-DD.md` が残っている場合、未移行の日付だけを初回オープン時に `diary.db` へ自動インポートする
+
+```sql
+CREATE TABLE IF NOT EXISTS diary_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  date TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_diary_entries_date ON diary_entries(date);
 ```
+
+### `CompositeMemoryStore` (`src/memory/composite-store.ts`)
+
+- `ICoreMemoryStore` と `IDiaryStore` を受け取り、`IMemoryStore` として委譲する
+- `close()` は `Promise.allSettled` で両方のストアを確実に閉じる
+
+## データ配置
+
+```text
 {dataDir}/
+├── diary.db
 └── memory/
-    ├── core/
-    │   └── memory.md          # 重要な記憶を蓄積（常時システムプロンプトに注入）
-    └── diary/
-        └── YYYY-MM-DD.md      # 日付ごとの日記
+    └── core/
+        └── memory.md
 ```
 
-### 実装方針
+## 実装方針
 
-- `node:fs/promises` で読み書き
-- ディレクトリは `{ recursive: true }` で遅延作成
-- **write-through cache + watcher**:
-  - `memory.md` は初回 read 時にメモリへ載せ、同一プロセス内の後続 read はキャッシュから返す。`fs.watch()` で親ディレクトリを監視し、外部変更も eager reload する
-  - diary 本文は date 単位の lazy cache を維持し、外部変更時は watcher でキャッシュを無効化して次回 read で再ロードする
-  - diary 日付一覧はキャッシュし、watcher で外部変更を検知したら無効化する
-- **mutex + atomic write**: memory.md と当日 diary は全スレッドから共有アクセスされるため、
-  書き込み時は mutex 取得 → temp ファイル書き込み → `rename`（atomic）で更新ロスト防止
-- diary は日付ごとの追記型ファイルとし、同じ日付への複数回の書き込みを保持する
-- `listDiaryDates()` はキャッシュ済み配列をそのまま返さず、常にコピーを返して内部状態の破壊を防ぐ
+- **core memory**
+  - 初回 read 時にキャッシュへ載せ、同一プロセス内の後続 read はキャッシュから返す
+  - `fs.watch()` で親ディレクトリを監視し、外部変更も eager reload する
+  - append 時は mutex 取得 → atomic write で更新ロストを防ぐ
+- **diary**
+  - 空文字列は保存しない
+  - 書き込み時に trim し、読取時は同日の複数エントリを `\n\n` で結合する
+  - `listDiaryDates()` は `SELECT DISTINCT date ... ORDER BY date ASC` で取得する
+  - `getRecentDiaries()` はタイムゾーン基準の日付文字列で範囲検索し、未来日付を除外する
+  - legacy diary import は `legacy_diary_imports` で冪等管理し、同日の SQLite 行が既に存在しても未移行の legacy file は 1 回だけ追加取り込みする
 
-### mutex の適用範囲
+## 並行性
 
-| ファイル                      | 操作     | mutex 必要 |
-| ----------------------------- | -------- | ---------- |
-| `memory/core/memory.md`       | 読み込み | 不要       |
-| `memory/core/memory.md`       | 書き込み | **必須**   |
-| `memory/diary/YYYY-MM-DD.md`  | 読み込み | 不要       |
-| `memory/diary/YYYY-MM-DD.md`（当日）| 書き込み | **必須** |
-| `memory/diary/YYYY-MM-DD.md`（過去）| 書き込み | 不要（上書き禁止が望ましい） |
+| 対象 | 方式 |
+| --- | --- |
+| `memory/core/memory.md` | `KeyedMutex` + atomic write |
+| `diary.db` | SQLite WAL ロック |
+
+`memory.md` は read-modify-write があるためアプリ側 mutex を使う。diary は append-only INSERT のため SQLite のロック制御に委譲する。
 
 ## セキュリティ: Prompt Injection 対策
 
 - memory / diary の内容はシステムプロンプトの instruction 部分と明確に区切る
-- `<memory>` / `<diary>` タグ等で **untrusted data** であることを明示
-- watcher 監視は親ディレクトリ単位で行い、atomic rename と整合するようにする
+- `<memory>` / `<diary>` タグ等で **untrusted data** であることを明示する
 
 ## テスト方針
 
-| テストケース             | 検証内容                                      |
-| ------------------------ | --------------------------------------------- |
-| read core（存在なし）    | 空文字列 or デフォルト値を返す                |
-| write + read core        | append した内容が読み込める                   |
-| concurrent write core    | mutex により内容が失われないことを確認         |
-| write + read diary       | 指定日の内容が追記され、読み込める            |
-| getRecentDiaries         | 直近 N 日分が昇順（時系列順）で返る            |
-| listDiaryDates           | 保存済み日付が一覧で返る                      |
-| cached diary date update | cache 温存中に古い日付を後から追加しても sort 順が壊れない |
-| defensive copy           | `listDiaryDates()` の返り値を mutate しても内部 cache が壊れない |
-| external change reload   | 外部から memory / diary を更新しても watcher 経由で反映される |
+| テストケース | 検証内容 |
+| --- | --- |
+| core read/write | `memory.md` の既定値・追記・外部更新反映 |
+| concurrent write core | mutex により内容が失われないこと |
+| diary write/read | 指定日の内容が保存され読み込めること |
+| diary multi-append | 同日複数エントリが挿入順で結合されること |
+| diary recent window | 直近 N 日・未来日付除外が正しく機能すること |
+| diary dates | 保存済み日付が昇順で一覧取得できること |
+| legacy diary import | 旧 `memory/diary/*.md` が一度だけ SQLite へ移行されること |
+| composite delegation | core/diary の各メソッドが正しい store に委譲されること |
+| composite close | 片方の close が失敗しても両方を close すること |

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { FilePromptContextStore } from './agent/prompt-context.js';
 import { createBot, type BotRuntime } from './bot.js';
 import { loadConfig } from './config.js';
 import { createScheduler, DiscordMessageSink, FileSchedulerStore } from './scheduler/index.js';
+import { CompositeMemoryStore } from './memory/composite-store.js';
+import { SqliteDiaryStore } from './memory/diary-store.js';
 import { FileMemoryStore } from './memory/store.js';
 import { FileSessionManager } from './session/manager.js';
 import { FileSkillStore } from './skill/store.js';
@@ -27,7 +29,9 @@ async function main(): Promise<void> {
     api: config.llmModelSelector.api,
     port: config.port,
   });
-  const memoryStore = new FileMemoryStore({ dataDir: config.dataDir, timezone: config.timezone });
+  const coreMemoryStore = new FileMemoryStore({ dataDir: config.dataDir });
+  const diaryStore = new SqliteDiaryStore({ dataDir: config.dataDir, timezone: config.timezone });
+  const memoryStore = new CompositeMemoryStore(coreMemoryStore, diaryStore);
   const userStore = new SqliteUserStore({ dataDir: config.dataDir });
   const sessionManager = new FileSessionManager({
     dataDir: config.dataDir,

--- a/src/memory/composite-store.ts
+++ b/src/memory/composite-store.ts
@@ -1,0 +1,51 @@
+import { createLogger } from '../utils/logger.js';
+import type { ICoreMemoryStore, IDiaryStore, DiaryEntry, IMemoryStore } from './types.js';
+
+const logger = createLogger('CompositeMemoryStore');
+
+export class CompositeMemoryStore implements IMemoryStore {
+  constructor(
+    private readonly coreMemoryStore: ICoreMemoryStore,
+    private readonly diaryStore: IDiaryStore,
+  ) {}
+
+  readCoreMemory(): Promise<string> {
+    return this.coreMemoryStore.readCoreMemory();
+  }
+
+  writeCoreMemory(content: string, mode: 'append'): Promise<void> {
+    return this.coreMemoryStore.writeCoreMemory(content, mode);
+  }
+
+  readDiary(date: string): Promise<string | null> {
+    return this.diaryStore.readDiary(date);
+  }
+
+  writeDiary(date: string, content: string): Promise<void> {
+    return this.diaryStore.writeDiary(date, content);
+  }
+
+  getRecentDiaries(days: number): Promise<DiaryEntry[]> {
+    return this.diaryStore.getRecentDiaries(days);
+  }
+
+  listDiaryDates(): Promise<string[]> {
+    return this.diaryStore.listDiaryDates();
+  }
+
+  async close(): Promise<void> {
+    const results = await Promise.allSettled([
+      this.coreMemoryStore.close(),
+      this.diaryStore.close(),
+    ]);
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    for (const failure of failures) {
+      logger.warn('Store close failed', failure.reason);
+    }
+    if (failures[0] != null) {
+      throw failures[0].reason;
+    }
+  }
+}

--- a/src/memory/diary-store.ts
+++ b/src/memory/diary-store.ts
@@ -1,0 +1,283 @@
+import { type Dirent, existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { formatDateInTimezone } from '../utils/date.js';
+import { createLogger } from '../utils/logger.js';
+import type { DiaryEntry, IDiaryStore } from './types.js';
+
+const logger = createLogger('SqliteDiaryStore');
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const LEGACY_DIARY_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.md$/;
+
+interface SqliteDiaryStoreOptions {
+  dataDir: string;
+  timezone?: string;
+}
+
+interface DiaryContentRow {
+  content: string;
+}
+
+interface DiaryEntryRow {
+  date: string;
+  content: string;
+}
+
+interface DiaryDateRow {
+  date: string;
+}
+
+
+export class SqliteDiaryStore implements IDiaryStore {
+  private readonly db: Database.Database;
+  private readonly timezone: string;
+  private readonly readDiaryStatement: Database.Statement<[string], DiaryContentRow>;
+  private readonly writeDiaryStatement: Database.Statement<[string, string, string]>;
+  private readonly getRecentDiariesStatement: Database.Statement<[string, string], DiaryEntryRow>;
+  private readonly listDiaryDatesStatement: Database.Statement<[], DiaryDateRow>;
+  private readonly hasLegacyImportStatement: Database.Statement<[string], { imported: 1 }>;
+  private readonly markLegacyImportStatement: Database.Statement<[string, string]>;
+
+  constructor({ dataDir, timezone = 'Asia/Tokyo' }: SqliteDiaryStoreOptions) {
+    const dbPath = join(dataDir, 'diary.db');
+    try {
+      mkdirSync(dataDir, { recursive: true });
+      this.db = new Database(dbPath);
+    } catch (error) {
+      throw new Error(`Failed to open diary database at ${dbPath}: ${error instanceof Error ? error.message : error}`);
+    }
+
+    try {
+      this.db.pragma('journal_mode = WAL');
+      this.db.pragma('synchronous = NORMAL');
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS diary_entries (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          date TEXT NOT NULL,
+          content TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS legacy_diary_imports (
+          date TEXT PRIMARY KEY,
+          imported_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_diary_entries_date ON diary_entries(date);
+      `);
+
+      this.timezone = timezone;
+      this.readDiaryStatement = this.db.prepare<[string], DiaryContentRow>(`
+        SELECT content
+        FROM diary_entries
+        WHERE date = ?
+        ORDER BY id ASC
+      `);
+      this.writeDiaryStatement = this.db.prepare(`
+        INSERT INTO diary_entries (date, content, created_at)
+        VALUES (?, ?, ?)
+      `);
+      this.getRecentDiariesStatement = this.db.prepare<[string, string], DiaryEntryRow>(`
+        SELECT date, content
+        FROM diary_entries
+        WHERE date >= ? AND date <= ?
+        ORDER BY date ASC, id ASC
+      `);
+      this.listDiaryDatesStatement = this.db.prepare<[], DiaryDateRow>(`
+        SELECT DISTINCT date
+        FROM diary_entries
+        ORDER BY date ASC
+      `);
+      this.hasLegacyImportStatement = this.db.prepare<[string], { imported: 1 }>(`
+        SELECT 1 AS imported
+        FROM legacy_diary_imports
+        WHERE date = ?
+      `);
+      this.markLegacyImportStatement = this.db.prepare(`
+        INSERT OR IGNORE INTO legacy_diary_imports (date, imported_at)
+        VALUES (?, ?)
+      `);
+      this.importLegacyDiaryFiles(join(dataDir, 'memory', 'diary'));
+    } catch (error) {
+      this.db.close();
+      throw error;
+    }
+  }
+
+  async readDiary(date: string): Promise<string | null> {
+    assertIsoDate(date);
+    const rows = this.readDiaryStatement.all(date);
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return rows.map((row) => row.content).join('\n\n');
+  }
+
+  async writeDiary(date: string, content: string): Promise<void> {
+    assertIsoDate(date);
+    const normalizedContent = content.trim();
+    if (normalizedContent.length === 0) {
+      return;
+    }
+
+    this.writeDiaryStatement.run(date, normalizedContent, new Date().toISOString());
+    logger.debug('Diary written', { date, contentLength: normalizedContent.length });
+    return Promise.resolve();
+  }
+
+  async getRecentDiaries(days: number): Promise<DiaryEntry[]> {
+    if (days <= 0) {
+      return [];
+    }
+
+    const { cutoffDate, todayDate } = getRecentDateRange(days, this.timezone);
+    const rows = this.getRecentDiariesStatement.all(cutoffDate, todayDate);
+    const groupedEntries = new Map<string, string[]>();
+
+    for (const row of rows) {
+      const normalizedContent = row.content.trim();
+      if (normalizedContent.length === 0) {
+        continue;
+      }
+
+      const entries = groupedEntries.get(row.date);
+      if (entries == null) {
+        groupedEntries.set(row.date, [normalizedContent]);
+      } else {
+        entries.push(normalizedContent);
+      }
+    }
+
+    const diaries = Array.from(groupedEntries.entries(), ([date, contents]) => ({
+      date,
+      content: contents.join('\n\n'),
+    }));
+    logger.debug('getRecentDiaries', { days, matchedCount: diaries.length });
+    return diaries;
+  }
+
+  async listDiaryDates(): Promise<string[]> {
+    const rows = this.listDiaryDatesStatement.all();
+    return rows.map((row) => row.date);
+  }
+
+  async close(): Promise<void> {
+    if (this.db.open) {
+      this.db.close();
+    }
+
+    return Promise.resolve();
+  }
+
+  private importLegacyDiaryFiles(legacyDiaryDir: string): void {
+    if (!existsSync(legacyDiaryDir)) {
+      return;
+    }
+
+    let legacyFiles: Dirent[];
+    try {
+      legacyFiles = readdirSync(legacyDiaryDir, { withFileTypes: true });
+    } catch (error) {
+      logger.warn('Failed to read legacy diary directory, skipping import', {
+        path: legacyDiaryDir,
+        error: error instanceof Error ? error.message : error,
+      });
+      return;
+    }
+
+    const importLegacyDiaryFile = this.db.transaction((entries: Array<{ date: string; content: string }>) => {
+      let importedCount = 0;
+      for (const entry of entries) {
+        const markResult = this.markLegacyImportStatement.run(entry.date, new Date().toISOString());
+        if (markResult.changes === 0) {
+          continue;
+        }
+
+        this.writeDiaryStatement.run(entry.date, entry.content, `${entry.date}T00:00:00.000Z`);
+        importedCount += 1;
+      }
+
+      return importedCount;
+    });
+
+    const entriesToImport: Array<{ date: string; content: string }> = [];
+    for (const legacyFile of legacyFiles) {
+      if (!legacyFile.isFile()) {
+        continue;
+      }
+
+      const match = LEGACY_DIARY_FILE_PATTERN.exec(legacyFile.name);
+      if (match == null) {
+        continue;
+      }
+
+      const date = match[1];
+      if (date == null) {
+        continue;
+      }
+
+      if (this.hasLegacyImportStatement.get(date) != null) {
+        continue;
+      }
+
+      let content: string;
+      try {
+        content = readFileSync(join(legacyDiaryDir, legacyFile.name), 'utf8').trim();
+      } catch (error) {
+        logger.warn('Failed to read legacy diary file, skipping', {
+          file: legacyFile.name,
+          error: error instanceof Error ? error.message : error,
+        });
+        continue;
+      }
+
+      if (content.length === 0) {
+        continue;
+      }
+
+      entriesToImport.push({ date, content });
+    }
+
+    if (entriesToImport.length === 0) {
+      return;
+    }
+
+    let importedCount: number;
+    try {
+      importedCount = importLegacyDiaryFile(entriesToImport);
+    } catch (error) {
+      logger.warn('Failed to execute legacy diary import transaction, skipping', {
+        entryCount: entriesToImport.length,
+        error: error instanceof Error ? error.message : error,
+      });
+      return;
+    }
+
+    if (importedCount > 0) {
+      logger.info('Imported legacy diary files into SQLite', { importedCount });
+    }
+  }
+}
+
+function getRecentDateRange(days: number, timezone: string): { cutoffDate: string; todayDate: string } {
+  const now = new Date();
+  const todayDate = formatDateInTimezone(now, timezone);
+
+  const year = Number(todayDate.slice(0, 4));
+  const month = Number(todayDate.slice(5, 7));
+  const day = Number(todayDate.slice(8, 10));
+  const cutoffLocal = new Date(Date.UTC(year, month - 1, day - (days - 1)));
+
+  const cutoffYear = String(cutoffLocal.getUTCFullYear());
+  const cutoffMonth = String(cutoffLocal.getUTCMonth() + 1).padStart(2, '0');
+  const cutoffDay = String(cutoffLocal.getUTCDate()).padStart(2, '0');
+
+  return { cutoffDate: `${cutoffYear}-${cutoffMonth}-${cutoffDay}`, todayDate };
+}
+
+function assertIsoDate(date: string): void {
+  if (!ISO_DATE_PATTERN.test(date)) {
+    throw new Error(`Invalid diary date "${date}": expected format YYYY-MM-DD`);
+  }
+}

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,62 +1,41 @@
-import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { formatDateInTimezone } from '../utils/date.js';
-import { isMissingFileError, readFileIfExists, writeFileAtomically } from '../utils/file.js';
+import { readFileIfExists, writeFileAtomically } from '../utils/file.js';
 import { FileWatcher } from '../utils/file-watcher.js';
 import { createLogger } from '../utils/logger.js';
 import { KeyedMutex } from '../utils/mutex.js';
-import type { DiaryEntry, IMemoryStore } from './types.js';
+import type { ICoreMemoryStore } from './types.js';
 
 const logger = createLogger('MemoryStore');
 
-const DIARY_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.md$/;
-const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-
 export interface FileMemoryStoreOptions {
   dataDir: string;
-  timezone?: string;
   mutex?: KeyedMutex;
   watcher?: FileWatcher;
 }
 
-export class FileMemoryStore implements IMemoryStore {
+export class FileMemoryStore implements ICoreMemoryStore {
   private readonly coreDir: string;
   private readonly coreMemoryPath: string;
-  private readonly diaryDir: string;
-  private readonly timezone: string;
   private readonly mutex: KeyedMutex;
   private readonly watcher: FileWatcher;
   private readonly ownsWatcher: boolean;
   private coreMemoryCache: string | undefined;
-  private readonly diaryContentCache = new Map<string, string | null>();
-  private diaryDatesCache: string[] | undefined;
   private readonly coreWatchDisposable;
-  private readonly diaryWatchDisposable;
   private coreReloadGeneration = 0;
 
   constructor({
     dataDir,
-    timezone = 'Asia/Tokyo',
     mutex = new KeyedMutex(),
     watcher,
   }: FileMemoryStoreOptions) {
     this.coreDir = join(dataDir, 'memory', 'core');
     this.coreMemoryPath = join(this.coreDir, 'memory.md');
-    this.diaryDir = join(dataDir, 'memory', 'diary');
-    this.timezone = timezone;
     this.mutex = mutex;
     this.watcher = watcher ?? new FileWatcher();
     this.ownsWatcher = watcher == null;
     this.coreWatchDisposable = this.watcher.watch(this.coreDir, () => this.reloadCoreMemory(), {
       filenameFilter: /^memory\.md$/,
-      debounceMs: 50,
-    });
-    this.diaryWatchDisposable = this.watcher.watch(this.diaryDir, async () => {
-      this.diaryContentCache.clear();
-      this.diaryDatesCache = undefined;
-    }, {
-      filenameFilter: DIARY_FILE_PATTERN,
       debounceMs: 50,
     });
   }
@@ -90,87 +69,8 @@ export class FileMemoryStore implements IMemoryStore {
     });
   }
 
-  async readDiary(date: string): Promise<string | null> {
-    const cached = this.diaryContentCache.get(date);
-    if (cached !== undefined) {
-      return cached;
-    }
-
-    const diaryPath = this.getDiaryPath(date);
-    const content = await readFileIfExists(diaryPath);
-    this.diaryContentCache.set(date, content);
-    return content;
-  }
-
-  async writeDiary(date: string, content: string): Promise<void> {
-    const diaryPath = this.getDiaryPath(date);
-    const normalizedContent = content.trim();
-
-    if (normalizedContent.length === 0) {
-      return;
-    }
-
-    await this.mutex.runExclusive(diaryPath, async () => {
-      const current = (await this.readDiary(date)) ?? '';
-      const next = appendContent(current, normalizedContent);
-      await writeFileAtomically(diaryPath, next);
-      this.diaryContentCache.set(date, next);
-      logger.debug('Diary written', { date, contentLength: normalizedContent.length });
-
-      if (this.diaryDatesCache != null && !this.diaryDatesCache.includes(date)) {
-        this.diaryDatesCache = [...this.diaryDatesCache, date].sort();
-      }
-    });
-  }
-
-  async getRecentDiaries(days: number): Promise<DiaryEntry[]> {
-    if (days <= 0) {
-      return [];
-    }
-
-    const { cutoffDate, todayDate } = getRecentDateRange(days, this.timezone);
-    const allDates = (await this.listDiaryDates()).sort();
-    const recentDates = allDates.filter((date) => date >= cutoffDate && date <= todayDate);
-
-    const diaries = await Promise.all(
-      recentDates.map(async (date) => ({
-        date,
-        content: (await this.readDiary(date)) ?? '',
-      })),
-    );
-
-    const result = diaries.filter((entry) => entry.content.length > 0);
-    logger.debug('getRecentDiaries', { days, matchedCount: result.length });
-    return result;
-  }
-
-  async listDiaryDates(): Promise<string[]> {
-    if (this.diaryDatesCache != null) {
-      return [...this.diaryDatesCache];
-    }
-
-    try {
-      const entries = await readdir(this.diaryDir, { withFileTypes: true });
-      const dates = entries
-        .filter((entry) => entry.isFile())
-        .map((entry) => DIARY_FILE_PATTERN.exec(entry.name)?.[1])
-        .filter((date): date is string => date != null)
-        .sort();
-      this.diaryDatesCache = dates;
-      return [...dates];
-    } catch (error) {
-      if (isMissingFileError(error)) {
-        this.diaryDatesCache = [];
-        return [];
-      }
-
-      throw error;
-    }
-  }
-
   async close(): Promise<void> {
     this.coreWatchDisposable.unsubscribe();
-    this.diaryWatchDisposable.unsubscribe();
 
     if (this.ownsWatcher) {
       await this.watcher.close();
@@ -190,30 +90,6 @@ export class FileMemoryStore implements IMemoryStore {
       logger.debug('Core memory reloaded from disk');
     });
   }
-
-  private getDiaryPath(date: string): string {
-    if (!ISO_DATE_PATTERN.test(date)) {
-      throw new Error(`Invalid diary date: ${date}`);
-    }
-
-    return join(this.diaryDir, `${date}.md`);
-  }
-}
-
-function getRecentDateRange(days: number, timezone: string): { cutoffDate: string; todayDate: string } {
-  const now = new Date();
-  const todayDate = formatDateInTimezone(now, timezone);
-
-  const year = Number(todayDate.slice(0, 4));
-  const month = Number(todayDate.slice(5, 7));
-  const day = Number(todayDate.slice(8, 10));
-  const cutoffLocal = new Date(year, month - 1, day - (days - 1));
-
-  const cy = String(cutoffLocal.getFullYear());
-  const cm = String(cutoffLocal.getMonth() + 1).padStart(2, '0');
-  const cd = String(cutoffLocal.getDate()).padStart(2, '0');
-
-  return { cutoffDate: `${cy}-${cm}-${cd}`, todayDate };
 }
 
 function appendContent(existing: string, entry: string): string {

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -3,12 +3,18 @@ export interface DiaryEntry {
   content: string;
 }
 
-export interface IMemoryStore {
+export interface ICoreMemoryStore {
   readCoreMemory(): Promise<string>;
   writeCoreMemory(content: string, mode: 'append'): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface IDiaryStore {
   readDiary(date: string): Promise<string | null>;
   writeDiary(date: string, content: string): Promise<void>;
   getRecentDiaries(days: number): Promise<DiaryEntry[]>;
   listDiaryDates(): Promise<string[]>;
   close(): Promise<void>;
 }
+
+export interface IMemoryStore extends ICoreMemoryStore, IDiaryStore {}

--- a/tests/composite-store.test.ts
+++ b/tests/composite-store.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CompositeMemoryStore } from '../src/memory/composite-store.js';
+import type { ICoreMemoryStore, IDiaryStore } from '../src/memory/types.js';
+
+function createCoreStore(): ICoreMemoryStore {
+  return {
+    readCoreMemory: vi.fn().mockResolvedValue('core memory'),
+    writeCoreMemory: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createDiaryStore(): IDiaryStore {
+  return {
+    readDiary: vi.fn().mockResolvedValue('diary entry'),
+    writeDiary: vi.fn().mockResolvedValue(undefined),
+    getRecentDiaries: vi.fn().mockResolvedValue([{ date: '2025-01-10', content: 'entry' }]),
+    listDiaryDates: vi.fn().mockResolvedValue(['2025-01-10']),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('CompositeMemoryStore', () => {
+  it('delegates core memory operations to the core store', async () => {
+    const coreStore = createCoreStore();
+    const diaryStore = createDiaryStore();
+    const store = new CompositeMemoryStore(coreStore, diaryStore);
+
+    await expect(store.readCoreMemory()).resolves.toBe('core memory');
+    await store.writeCoreMemory('new memory', 'append');
+
+    expect(coreStore.readCoreMemory).toHaveBeenCalledTimes(1);
+    expect(coreStore.writeCoreMemory).toHaveBeenCalledWith('new memory', 'append');
+  });
+
+  it('delegates diary operations to the diary store', async () => {
+    const coreStore = createCoreStore();
+    const diaryStore = createDiaryStore();
+    const store = new CompositeMemoryStore(coreStore, diaryStore);
+
+    await expect(store.readDiary('2025-01-10')).resolves.toBe('diary entry');
+    await store.writeDiary('2025-01-10', 'more diary');
+    await expect(store.getRecentDiaries(3)).resolves.toEqual([{ date: '2025-01-10', content: 'entry' }]);
+    await expect(store.listDiaryDates()).resolves.toEqual(['2025-01-10']);
+
+    expect(diaryStore.readDiary).toHaveBeenCalledWith('2025-01-10');
+    expect(diaryStore.writeDiary).toHaveBeenCalledWith('2025-01-10', 'more diary');
+    expect(diaryStore.getRecentDiaries).toHaveBeenCalledWith(3);
+    expect(diaryStore.listDiaryDates).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes both stores', async () => {
+    const coreStore = createCoreStore();
+    const diaryStore = createDiaryStore();
+    const store = new CompositeMemoryStore(coreStore, diaryStore);
+
+    await store.close();
+
+    expect(coreStore.close).toHaveBeenCalledTimes(1);
+    expect(diaryStore.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('still closes both stores when one close fails', async () => {
+    const coreStore = createCoreStore();
+    const diaryStore = createDiaryStore();
+    vi.mocked(coreStore.close).mockRejectedValueOnce(new Error('core close failed'));
+    const store = new CompositeMemoryStore(coreStore, diaryStore);
+
+    await expect(store.close()).rejects.toThrow('core close failed');
+    expect(coreStore.close).toHaveBeenCalledTimes(1);
+    expect(diaryStore.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the first failure when both close calls fail', async () => {
+    const coreStore = createCoreStore();
+    const diaryStore = createDiaryStore();
+    vi.mocked(coreStore.close).mockRejectedValueOnce(new Error('core failed'));
+    vi.mocked(diaryStore.close).mockRejectedValueOnce(new Error('diary failed'));
+    const store = new CompositeMemoryStore(coreStore, diaryStore);
+
+    await expect(store.close()).rejects.toThrow('core failed');
+    expect(coreStore.close).toHaveBeenCalledTimes(1);
+    expect(diaryStore.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/diary.store.test.ts
+++ b/tests/diary.store.test.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SqliteDiaryStore } from '../src/memory/diary-store.js';
+
+const temporaryDirectories: string[] = [];
+const stores: SqliteDiaryStore[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.all(stores.splice(0).map((store) => store.close()));
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
+async function createStore() {
+  const dataDir = join(process.cwd(), '.test-artifacts', `karakuri-diary-store-${randomUUID()}`);
+  await mkdir(dataDir, { recursive: true });
+  temporaryDirectories.push(dataDir);
+  const store = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+  stores.push(store);
+  return { dataDir, store };
+}
+
+async function runStartupImportInSeparateProcess(dataDir: string): Promise<void> {
+  const tsxCliPath = join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
+  const diaryStoreModuleUrl = pathToFileURL(
+    join(process.cwd(), 'src', 'memory', 'diary-store.ts'),
+  ).href;
+  const child = spawn(
+    process.execPath,
+    [
+      tsxCliPath,
+      '--eval',
+      `
+        import { SqliteDiaryStore } from ${JSON.stringify(diaryStoreModuleUrl)};
+
+        const store = new SqliteDiaryStore({ dataDir: ${JSON.stringify(dataDir)}, timezone: 'UTC' });
+        store.close().catch((error) => {
+          console.error(error);
+          process.exitCode = 1;
+        });
+      `,
+    ],
+    { cwd: process.cwd(), stdio: 'pipe' },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`Startup import process failed with code ${code}: ${stderr}`));
+    });
+  });
+}
+
+describe('SqliteDiaryStore', () => {
+  it('returns null when a diary entry does not exist', async () => {
+    const { store } = await createStore();
+
+    await expect(store.readDiary('2025-01-10')).resolves.toBeNull();
+  });
+
+  it('rejects malformed date strings', async () => {
+    const { store } = await createStore();
+
+    await expect(store.readDiary('not-a-date')).rejects.toThrow('expected format YYYY-MM-DD');
+    await expect(store.writeDiary('2025/01/10', 'note')).rejects.toThrow('expected format YYYY-MM-DD');
+  });
+
+  it('skips writing an empty string', async () => {
+    const { store } = await createStore();
+
+    await store.writeDiary('2025-01-10', '');
+
+    await expect(store.readDiary('2025-01-10')).resolves.toBeNull();
+  });
+
+  it('returns an empty array when days is zero or negative', async () => {
+    const { store } = await createStore();
+    await store.writeDiary('2025-01-10', 'note');
+
+    await expect(store.getRecentDiaries(0)).resolves.toEqual([]);
+    await expect(store.getRecentDiaries(-1)).resolves.toEqual([]);
+  });
+
+  it('can be closed multiple times without error', async () => {
+    const { store } = await createStore();
+
+    await store.close();
+    await expect(store.close()).resolves.toBeUndefined();
+  });
+
+  it('writes and reads a diary entry', async () => {
+    const { store } = await createStore();
+
+    await store.writeDiary('2025-01-10', 'First note');
+
+    await expect(store.readDiary('2025-01-10')).resolves.toBe('First note');
+  });
+
+  it('joins multiple entries from the same day in insertion order', async () => {
+    const { store } = await createStore();
+
+    await store.writeDiary('2025-01-10', 'First note');
+    await store.writeDiary('2025-01-10', 'Second note');
+
+    await expect(store.readDiary('2025-01-10')).resolves.toBe('First note\n\nSecond note');
+  });
+
+  it('skips empty content and trims stored entries', async () => {
+    const { store } = await createStore();
+
+    await store.writeDiary('2025-01-10', '   ');
+    await store.writeDiary('2025-01-10', '  Trimmed note  ');
+
+    await expect(store.readDiary('2025-01-10')).resolves.toBe('Trimmed note');
+    await expect(store.listDiaryDates()).resolves.toEqual(['2025-01-10']);
+  });
+
+  it('returns recent diaries within the calendar window and excludes future dates', async () => {
+    const { store } = await createStore();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-10T12:00:00Z'));
+
+    await store.writeDiary('2025-01-07', 'outside window');
+    await store.writeDiary('2025-01-08', 'day one');
+    await store.writeDiary('2025-01-10', 'day three first');
+    await store.writeDiary('2025-01-10', 'day three second');
+    await store.writeDiary('2025-01-11', 'future note');
+
+    await expect(store.getRecentDiaries(3)).resolves.toEqual([
+      { date: '2025-01-08', content: 'day one' },
+      { date: '2025-01-10', content: 'day three first\n\nday three second' },
+    ]);
+  });
+
+  it('lists saved diary dates in ascending order', async () => {
+    const { store } = await createStore();
+
+    await store.writeDiary('2025-01-12', 'later');
+    await store.writeDiary('2025-01-10', 'earlier');
+    await store.writeDiary('2025-01-11', 'middle');
+
+    await expect(store.listDiaryDates()).resolves.toEqual([
+      '2025-01-10',
+      '2025-01-11',
+      '2025-01-12',
+    ]);
+  });
+
+  it('persists entries across close and reopen', async () => {
+    const { dataDir, store } = await createStore();
+
+    await store.writeDiary('2025-01-10', 'Persistent note');
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    const reopened = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(reopened);
+
+    await expect(reopened.readDiary('2025-01-10')).resolves.toBe('Persistent note');
+  });
+
+  it('skips reading legacy files that were already imported on later startups', async () => {
+    const { dataDir, store } = await createStore();
+    const legacyDiaryDir = join(dataDir, 'memory', 'diary');
+    const legacyFilePath = join(legacyDiaryDir, '2025-01-10.md');
+    await mkdir(legacyDiaryDir, { recursive: true });
+    await writeFile(legacyFilePath, 'Legacy note\n', 'utf8');
+
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    const imported = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(imported);
+    await expect(imported.readDiary('2025-01-10')).resolves.toBe('Legacy note');
+
+    await imported.close();
+    stores.splice(stores.indexOf(imported), 1);
+    await chmod(legacyFilePath, 0o000);
+
+    const reopened = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(reopened);
+    await expect(reopened.readDiary('2025-01-10')).resolves.toBe('Legacy note');
+  });
+
+  it('imports legacy file-based diary entries once on startup', async () => {
+    const { dataDir, store } = await createStore();
+    const legacyDiaryDir = join(dataDir, 'memory', 'diary');
+    await mkdir(legacyDiaryDir, { recursive: true });
+    await writeFile(join(legacyDiaryDir, '2025-01-10.md'), 'Legacy note\n', 'utf8');
+
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    const imported = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(imported);
+    await expect(imported.readDiary('2025-01-10')).resolves.toBe('Legacy note');
+    await expect(imported.listDiaryDates()).resolves.toEqual(['2025-01-10']);
+
+    await imported.close();
+    stores.splice(stores.indexOf(imported), 1);
+
+    const reopened = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(reopened);
+    await expect(reopened.readDiary('2025-01-10')).resolves.toBe('Legacy note');
+    await expect(reopened.listDiaryDates()).resolves.toEqual(['2025-01-10']);
+  });
+
+  it('imports legacy content even when sqlite already has the same date', async () => {
+    const { dataDir, store } = await createStore();
+    const legacyDiaryDir = join(dataDir, 'memory', 'diary');
+    await mkdir(legacyDiaryDir, { recursive: true });
+
+    await store.writeDiary('2025-01-10', 'SQLite note');
+    await writeFile(join(legacyDiaryDir, '2025-01-10.md'), 'Legacy note\n', 'utf8');
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    const imported = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(imported);
+    await expect(imported.readDiary('2025-01-10')).resolves.toBe('SQLite note\n\nLegacy note');
+
+    await imported.close();
+    stores.splice(stores.indexOf(imported), 1);
+
+    const reopened = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(reopened);
+    await expect(reopened.readDiary('2025-01-10')).resolves.toBe('SQLite note\n\nLegacy note');
+  });
+
+  it('ignores date-named legacy directories during startup import', async () => {
+    const { dataDir, store } = await createStore();
+    const legacyDiaryDir = join(dataDir, 'memory', 'diary');
+    await mkdir(join(legacyDiaryDir, '2025-01-10.md'), { recursive: true });
+    await writeFile(join(legacyDiaryDir, '2025-01-11.md'), 'Legacy note\n', 'utf8');
+
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    const reopened = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(reopened);
+
+    await expect(reopened.readDiary('2025-01-11')).resolves.toBe('Legacy note');
+    await expect(reopened.readDiary('2025-01-10')).resolves.toBeNull();
+    await expect(reopened.listDiaryDates()).resolves.toEqual(['2025-01-11']);
+  });
+
+  it('handles concurrent legacy imports without duplicate entries or startup failures', async () => {
+    const { dataDir, store } = await createStore();
+    const legacyDiaryDir = join(dataDir, 'memory', 'diary');
+    await mkdir(legacyDiaryDir, { recursive: true });
+    await writeFile(join(legacyDiaryDir, '2025-01-10.md'), 'Legacy note\n', 'utf8');
+
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    await expect(
+      Promise.all([
+        runStartupImportInSeparateProcess(dataDir),
+        runStartupImportInSeparateProcess(dataDir),
+      ]),
+    ).resolves.toBeDefined();
+
+    const reopened = new SqliteDiaryStore({ dataDir, timezone: 'UTC' });
+    stores.push(reopened);
+
+    await expect(reopened.readDiary('2025-01-10')).resolves.toBe('Legacy note');
+    await expect(reopened.listDiaryDates()).resolves.toEqual(['2025-01-10']);
+  });
+});

--- a/tests/memory.store.test.ts
+++ b/tests/memory.store.test.ts
@@ -1,5 +1,5 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -19,18 +19,12 @@ afterEach(async () => {
 });
 
 async function createStore() {
-  const dataDir = await mkdtemp(join(tmpdir(), 'karakuri-memory-'));
+  const dataDir = join(process.cwd(), '.test-artifacts', `karakuri-memory-${randomUUID()}`);
+  await mkdir(dataDir, { recursive: true });
   temporaryDirectories.push(dataDir);
-  const store = new FileMemoryStore({ dataDir, timezone: 'UTC' });
+  const store = new FileMemoryStore({ dataDir });
   stores.push(store);
   return { dataDir, store };
-}
-
-function toDateString(date: Date): string {
-  const y = String(date.getUTCFullYear());
-  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
-  const d = String(date.getUTCDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
 }
 
 describe('FileMemoryStore', () => {
@@ -55,96 +49,18 @@ describe('FileMemoryStore', () => {
     }
   });
 
-  it('keeps cached diary dates sorted and returns defensive copies', async () => {
-    const { store } = await createStore();
-
-    await expect(store.listDiaryDates()).resolves.toEqual([]);
-
-    await store.writeDiary('2025-01-02', 'newer note');
-    await store.writeDiary('2025-01-01', 'older note');
-
-    const diaryDates = await store.listDiaryDates();
-    expect(diaryDates).toEqual(['2025-01-01', '2025-01-02']);
-
-    diaryDates.push('2099-01-01');
-
-    await expect(store.listDiaryDates()).resolves.toEqual(['2025-01-01', '2025-01-02']);
-  });
-
-  it('stores diary entries and returns recent diary dates in reverse chronological order', async () => {
-    const { store } = await createStore();
-
-    const today = new Date();
-    const todayStr = toDateString(today);
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayStr = toDateString(yesterday);
-
-    await store.writeDiary(yesterdayStr, 'older note');
-    await store.writeDiary(todayStr, 'newer note');
-    await store.writeDiary(todayStr, 'follow-up note');
-
-    await expect(store.listDiaryDates()).resolves.toEqual([yesterdayStr, todayStr].sort());
-
-    const diary = await store.readDiary(todayStr);
-    expect(diary).toContain('newer note');
-    expect(diary).toContain('follow-up note');
-
-    const recent = await store.getRecentDiaries(2);
-    expect(recent).toEqual([
-      {
-        date: yesterdayStr,
-        content: expect.stringContaining('older note'),
-      },
-      {
-        date: todayStr,
-        content: expect.stringContaining('newer note'),
-      },
-    ]);
-  });
-
-  it('excludes diary entries older than the calendar window', async () => {
-    const { store } = await createStore();
-
-    await store.writeDiary('2020-01-01', 'ancient note');
-
-    const recent = await store.getRecentDiaries(3);
-    expect(recent).toEqual([]);
-
-    await expect(store.listDiaryDates()).resolves.toEqual(['2020-01-01']);
-  });
-
-  it('excludes future-dated diary entries from recent diaries', async () => {
-    const { store } = await createStore();
-
-    const today = new Date();
-    const todayStr = toDateString(today);
-    await store.writeDiary(todayStr, 'today note');
-    await store.writeDiary('2099-01-01', 'future note');
-
-    const recent = await store.getRecentDiaries(3);
-    expect(recent).toHaveLength(1);
-    expect(recent[0]!.date).toBe(todayStr);
-    expect(recent[0]!.content).toContain('today note');
-  });
-
-  it('reloads core memory and invalidates diary cache after external edits', async () => {
+  it('reloads core memory after external edits', async () => {
     const { dataDir, store } = await createStore();
     const corePath = join(dataDir, 'memory', 'core', 'memory.md');
-    const diaryPath = join(dataDir, 'memory', 'diary', '2025-01-01.md');
 
     await store.writeCoreMemory('before', 'append');
-    await store.writeDiary('2025-01-01', 'first');
 
     await expect(store.readCoreMemory()).resolves.toContain('before');
-    await expect(store.readDiary('2025-01-01')).resolves.toContain('first');
 
     await writeFile(corePath, 'after\n', 'utf8');
-    await writeFile(diaryPath, 'external\n', 'utf8');
 
     await vi.waitFor(async () => {
       await expect(store.readCoreMemory()).resolves.toBe('after\n');
-      await expect(store.readDiary('2025-01-01')).resolves.toBe('external\n');
     }, { timeout: 1_500 });
   });
 });


### PR DESCRIPTION
## Summary

- CompositeMemoryStoreパターンにより既存 `IMemoryStore` インターフェースを維持しつつ、日記のみSQLite化
- `ICoreMemoryStore` / `IDiaryStore` にインターフェースを分割し、`IMemoryStore extends ICoreMemoryStore, IDiaryStore` で後方互換性を維持
- `SqliteDiaryStore`: WAL モード + prepared statements、レガシーファイル自動インポート（冪等・並行安全）
- `CompositeMemoryStore`: 両ストアを委譲で合成、`Promise.allSettled` による安全な close
- `FileMemoryStore` をコアメモリ専用に縮小（未使用の `timezone` オプション削除）
- コンストラクタの2段階 try-catch でDB初期化失敗時のリソースリーク防止
- レガシーインポートはベストエフォート（ファイル読み取り・ディレクトリ読み取り・トランザクション実行すべて個別にエラーハンドリング）

## Test plan

- [x] `npx tsc --noEmit` パス
- [x] `npx vitest run` 全37ファイル / 324テスト パス
- [x] SqliteDiaryStore: CRUD、日付バリデーション、空文字スキップ、境界値、冪等 close、レガシーインポート（冪等・並行・権限エラー）
- [x] CompositeMemoryStore: 委譲、close 失敗（片方/両方）
- [x] FileMemoryStore: コアメモリ CRUD、外部編集リロード

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)