### PR TITLE
[codex] Ignore Docker Compose override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/
 dist/
 coverage/
 .vitest/
+docker-compose.override.yml


### PR DESCRIPTION
## Summary
- Ignore `docker-compose.override.yml` so local Compose overrides do not appear in git status.

## Context
- Local Docker networking can use `docker-compose.override.yml` for environment-specific settings such as joining an external LLM proxy network.
- The override file should remain local to avoid committing machine-specific Compose settings.

## Validation
- Ran `git check-ignore -v docker-compose.override.yml` and confirmed it is ignored by `.gitignore`.