### PR TITLE
[codex] Skip enable_thinking for chat completions

### DIFF
--- a/src/llm/no-thinking-fetch.ts
+++ b/src/llm/no-thinking-fetch.ts
@@ -12,6 +12,10 @@ export function noThinkingProviderOptions(api: OpenAiApiKind): ProviderOptions {
 
 export function createNoThinkingFetch(baseFetch: typeof globalThis.fetch = globalThis.fetch): typeof globalThis.fetch {
   return async (input, init) => {
+    if (isChatCompletionsRequest(input)) {
+      return baseFetch(input, init);
+    }
+
     if (init?.body != null && typeof init.body === 'string') {
       try {
         const json = JSON.parse(init.body) as Record<string, unknown>;
@@ -24,4 +28,14 @@ export function createNoThinkingFetch(baseFetch: typeof globalThis.fetch = globa
 
     return baseFetch(input, init);
   };
+}
+
+function isChatCompletionsRequest(input: string | URL | Request): boolean {
+  const url = typeof input === 'string'
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+  return url.includes('/chat/completions');
 }

--- a/tests/no-thinking-fetch.test.ts
+++ b/tests/no-thinking-fetch.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createNoThinkingFetch, noThinkingProviderOptions } from '../src/llm/no-thinking-fetch.js';
 
 describe('createNoThinkingFetch', () => {
-  it('injects enable_thinking: false into JSON request bodies', async () => {
+  it('does not inject enable_thinking into chat completions request bodies', async () => {
     const baseFetch = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => new Response('ok'));
     const fetch = createNoThinkingFetch(baseFetch);
 
@@ -15,7 +15,7 @@ describe('createNoThinkingFetch', () => {
     expect(baseFetch).toHaveBeenCalledTimes(1);
     const init = baseFetch.mock.calls[0]![1]!;
     const body = JSON.parse(init.body as string);
-    expect(body.enable_thinking).toBe(false);
+    expect(body.enable_thinking).toBeUndefined();
     expect(body.model).toBe('qwen3.5-plus');
     expect(body.messages).toEqual([]);
   });
@@ -24,7 +24,7 @@ describe('createNoThinkingFetch', () => {
     const baseFetch = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) => new Response('ok'));
     const fetch = createNoThinkingFetch(baseFetch);
 
-    await fetch('https://api.example.com/v1/chat/completions', {
+    await fetch('https://api.example.com/v1/responses', {
       method: 'POST',
       body: JSON.stringify({ model: 'test', temperature: 0.7, stream: true }),
     });


### PR DESCRIPTION
## Summary

- Skip `enable_thinking=false` injection for OpenAI-compatible Chat Completions requests.
- Keep the existing no-thinking body injection for non-chat requests.
- Update the no-thinking fetch tests to cover the chat-completions passthrough behavior.

## Why

The free proxy currently routes `openai/chat/qwen3.7-plus` through `/chat/completions`, and the upstream Cerebras-compatible endpoint rejects the `enable_thinking` field with `wrong_api_format`. Chat API usage should not include that field.

## Validation

- `docker compose up -d --build bot` completed successfully and rebuilt the TypeScript `dist` output.
- Confirmed the running container is healthy.
- Confirmed `/app/dist/llm/no-thinking-fetch.js` contains the chat completions guard.
- Local targeted Vitest run was not available because local `node_modules` is missing (`vitest: not found`).