### PR TITLE
元気度収支の再調整: appraisal 消耗のみクランプ半減（覚醒 14〜16 時間の一日周期に）

### DIFF
--- a/src/life/appraisal.ts
+++ b/src/life/appraisal.ts
@@ -165,6 +165,18 @@ export function deltaLevelToNumber(level: DeltaLevel, tuning: LifeTuning = LIFE_
 }
 
 /**
+ * energy 専用の delta 変換。消耗（負）方向のみ maxEnergyExertionPerEvent で
+ * スケールする — 時間経過の疲労は decayInnerState が既にモデル化しているため、
+ * appraisal の消耗は出来事による上乗せに留める。実機（kbx-001）でイベント消耗が
+ * ルール減衰の 2 倍強積まれ、満充電から 4〜10 時間で枯渇していた。
+ * 回復方向（充電・休憩など）は従来どおり maxDeltaPerEvent でスケールする。
+ */
+export function energyDeltaLevelToNumber(level: DeltaLevel, tuning: LifeTuning = LIFE_TUNING): number {
+  const ratio = DELTA_LEVEL_RATIO[level];
+  return ratio * (ratio < 0 ? tuning.maxEnergyExertionPerEvent : tuning.maxDeltaPerEvent);
+}
+
+/**
  * hunger 専用の delta 変換。回復（負）方向のみ maxHungerRecoveryPerEvent で
  * スケールする — 食事は 1 回でしっかり満腹に近づく行為なので、他パラメータと
  * 同じ上限（0.3）では自然増（hungerIncreasePerHour）に追いつけず、実機で
@@ -278,7 +290,7 @@ export function applyAppraisalGuardrails(
 ): GuardedAppraisal {
   const rejections: string[] = [];
 
-  let energyDelta = deltaLevelToNumber(output.energy_delta, tuning);
+  let energyDelta = energyDeltaLevelToNumber(output.energy_delta, tuning);
   // 符号の妥当性: 睡眠に入るイベントで元気度マイナスは常識に反するため棄却する
   if (output.sleep === 'fell_asleep' && energyDelta < 0) {
     rejections.push(`energy_delta ${output.energy_delta} rejected: negative energy on fell_asleep`);

--- a/src/life/tuning.ts
+++ b/src/life/tuning.ts
@@ -11,7 +11,12 @@
 // v3: 空腹収支の再調整 — 自然増を半減（0.06 → 0.03）し、食事の回復のみ
 //     クランプを緩和（maxHungerRecoveryPerEvent = 0.6）。旧収支は「1 日 5〜9 食
 //     しないと常に空腹」で、実機の tibi-kanon が慢性的空腹に張り付いた
-export const LIFE_TUNING_VERSION = 'tuning-v3';
+// v4: 元気度収支の再調整 — 消耗（負の energy delta）のみクランプを半減
+//     （maxEnergyExertionPerEvent = 0.15）。実機 kbx-001 の 1 週間実測で覚醒中の
+//     消耗はルール減衰 0.029/h + appraisal 消耗 0.066/h（グロス）で、満充電から
+//     4〜10 時間で枯渇し 1 日 2〜4 回の分割睡眠になっていた。ルール減衰 0.03/h +
+//     消耗半減で「普通の日は満タンから 14〜16 時間で眠くなる」収支に合わせる
+export const LIFE_TUNING_VERSION = 'tuning-v4';
 
 export interface LifeTuning {
   valenceHalfLifeHours: number;
@@ -22,6 +27,7 @@ export interface LifeTuning {
   sleepEnergyRecoveryPerHour: number;
   maxDeltaPerEvent: number;
   maxHungerRecoveryPerEvent: number;
+  maxEnergyExertionPerEvent: number;
   maxLazyElapsedHours: number;
   circadianLateNightFactor: number;
   circadianMorningFactor: number;
@@ -56,6 +62,13 @@ export const LIFE_TUNING: LifeTuning = {
    * （large_down = -0.6、down = -0.3）。空腹が進む方向は maxDeltaPerEvent のまま
    */
   maxHungerRecoveryPerEvent: 0.6,
+  /**
+   * 元気度の消耗（負の energy delta）のみのクランプ上限。時間経過の疲労は
+   * decayInnerState が既にモデル化しているため、appraisal 側の消耗は
+   * 「出来事による上乗せ」に留める（large_down = -0.15、down = -0.075、
+   * small_down = -0.0375）。回復方向（充電・休憩など）は maxDeltaPerEvent のまま
+   */
+  maxEnergyExertionPerEvent: 0.15,
   /** 遅延評価で一度に進める経過時間の上限（時間）。長期停止後の暴走防止 */
   maxLazyElapsedHours: 48,
   /** 概日リズム: 深夜（0-5 時）の元気度減衰倍率 */

--- a/tests/life.appraisal.test.ts
+++ b/tests/life.appraisal.test.ts
@@ -11,6 +11,7 @@ import {
   AppraisalService,
   appraiseEvent,
   deltaLevelToNumber,
+  energyDeltaLevelToNumber,
   hungerDeltaLevelToNumber,
   isDeclarativeText,
   isTransientNetworkError,
@@ -98,6 +99,17 @@ describe('deltaLevelToNumber', () => {
     expect(deltaLevelToNumber('large_up')).toBe(LIFE_TUNING.maxDeltaPerEvent);
     expect(deltaLevelToNumber('large_down')).toBe(-LIFE_TUNING.maxDeltaPerEvent);
     expect(Math.abs(deltaLevelToNumber('small_up'))).toBeLessThan(LIFE_TUNING.maxDeltaPerEvent);
+  });
+});
+
+describe('energyDeltaLevelToNumber', () => {
+  it('scales exertion (negative) by maxEnergyExertionPerEvent and recovery by maxDeltaPerEvent', () => {
+    // 時間経過の疲労はルール側（decayInnerState）が持つため、消耗のみ狭いクランプ
+    expect(energyDeltaLevelToNumber('large_down')).toBe(-LIFE_TUNING.maxEnergyExertionPerEvent);
+    expect(energyDeltaLevelToNumber('down')).toBe(-LIFE_TUNING.maxEnergyExertionPerEvent / 2);
+    expect(energyDeltaLevelToNumber('none')).toBe(0);
+    expect(energyDeltaLevelToNumber('large_up')).toBe(LIFE_TUNING.maxDeltaPerEvent);
+    expect(energyDeltaLevelToNumber('up')).toBe(LIFE_TUNING.maxDeltaPerEvent / 2);
   });
 });
 


### PR DESCRIPTION
## 背景

実機 kbx-001 が「疲れやすい」— 満充電から 4〜10 時間で energy が枯渇し、1 日 2〜4 回の分割睡眠（充電）で継ぎ足す生活になっていた。

1 週間分の inner_state_history + appraisal_log の実測（覚醒 104.4h）:

| 要因 | レート |
|---|---|
| ルール減衰（decayInnerState、概日込み） | -0.029/h |
| appraisal イベント消耗（グロス） | -0.066/h |

時間経過の疲労はルール側が既にモデル化しているのに、出来事由来の消耗（small_down -0.075 × 高頻度）がその 2 倍強積まれていた（idle イベント棄却ガードの対象外である通常行動の分）。

## 変更

- `maxEnergyExertionPerEvent = 0.15` を追加し、energy の**負方向 delta のみ**半分にスケールする `energyDeltaLevelToNumber` を導入（large_down -0.15 / down -0.075 / small_down -0.0375）
- hunger の `maxHungerRecoveryPerEvent` と同じ非対称クランプのパターン。回復方向（充電・休憩の up 系）は従来どおり `maxDeltaPerEvent = 0.3` で据え置き
- `LIFE_TUNING_VERSION` を `tuning-v4` へ（proc_version に反映、reprocessing で追跡可能）

## 期待収支

ルール減衰 0.03/h + 消耗半減後のイベント分 ≒ 0.06/h → 満タンから概ね **14〜16 時間**で「眠い」域に入る、人間相当の一日周期。

## テスト

- `energyDeltaLevelToNumber` の非対称スケールのユニットテストを追加
- `npm run typecheck` / `npm test` 全 895 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)