### PR TITLE
GHCR へのイメージ公開ワークフローを追加

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,61 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    name: Build and push image to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,9 +12,11 @@ permissions:
   contents: read
   packages: write
 
+# 同一 ref の連続 push では古い run をキャンセルする。直列化 (false) だと
+# run の実行順が保証されず、古いコミットのイメージが latest を上書きしうるため。
 concurrency:
   group: docker-publish-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-and-push:
@@ -22,10 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -33,7 +37,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/${{ github.repository }}
           flavor: |
@@ -46,10 +50,10 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## 概要

karakuri-agent の Docker イメージを GitHub Actions で事前ビルドし、GHCR（`ghcr.io/karakuriagent/karakuri-agent`）へ公開するワークフローを追加します。別リポジトリで進めるインスタンスマネージャーが「pull して起動するだけ」で使えるようにするための下準備です。

## 内容

- `.github/workflows/docker-publish.yml` を新規追加
  - トリガー: `main` への push / `v*` タグ push / `workflow_dispatch`（PR ではビルドしない）
  - タグ付け: main → `latest`、`v1.2.3` → `1.2.3` / `1.2` / `1`、常に `sha-<short>`
  - buildx + GHA キャッシュ（`type=gha`）、`linux/amd64` のみ（sqlite-vec の glibc プリビルド前提に合わせる）
  - 認証は `GITHUB_TOKEN`（`packages: write` を明示）
  - 同一 ref の連続 push は `concurrency` で直列化

## 検証

- `js-yaml` でのパースと `@action-validator/cli` によるワークフロースキーマ検証を通過
- Dockerfile は変更なし。ランタイムが読む外部ファイルはすべて `DATA_DIR` 配下であることを確認済みで、dist のみのイメージで完結する

## マージ後の確認

- 初回実行後、GHCR 側でパッケージの可視性（public にするか）とリポジトリ連携を確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated container image builds and publishing for main branch updates, version releases, and manually triggered runs.
  * Published images now receive standard release, latest, and commit-based tags.
  * Enabled build caching and controlled concurrent publishing to improve reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->